### PR TITLE
Fix code scanning alert no. 2: Clear-text storage of sensitive information

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,8 @@
 # Users
 User.create!(name:  "Example User",
              email: "example@railstutorial.org",
-             password:              "foobar",
-             password_confirmation: "foobar",
+             password:              BCrypt::Password.create("foobar"),
+             password_confirmation: BCrypt::Password.create("foobar"),
              admin:     true,
              activated: true,
              activated_at: Time.zone.now)
@@ -10,7 +10,7 @@ User.create!(name:  "Example User",
 99.times do |n|
   name  = Faker::Name.name
   email = "example-#{n+1}@railstutorial.org"
-  password = "password"
+  password = BCrypt::Password.create("password")
   User.create!(name:  name,
                email: email,
                password:              password,


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_8/security/code-scanning/2](https://github.com/Brook-5686/Ruby_8/security/code-scanning/2)

To fix the problem, we need to ensure that passwords are hashed before being stored in the database. This can be achieved by using a hashing function, such as bcrypt, which is a widely used and secure hashing algorithm. The bcrypt library should be used to hash the passwords before they are passed to the `User.create!` method.

1. Install the bcrypt gem if it is not already installed.
2. Update the code in `db/seeds.rb` to hash the passwords before storing them.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
